### PR TITLE
Implement mapping between videos and channel domains

### DIFF
--- a/lib/holobot/holofans/channels.ex
+++ b/lib/holobot/holofans/channels.ex
@@ -51,6 +51,16 @@ defmodule Holobot.Holofans.Channels do
     end)
   end
 
+  @doc """
+  Get a channel by its Youtube channel ID.
+  """
+  @spec get_channel(binary()) :: %Channel{} | nil
+  def get_channel(yt_channel_id) do
+    Memento.transaction!(fn ->
+      Memento.Query.read(Channel, yt_channel_id)
+    end)
+  end
+
   @spec get_channels_top_subs(integer) :: [any]
   def get_channels_top_subs(limit \\ 10) do
     get_channels() |> Enum.sort_by(& &1.subscriber_count, :desc) |> Enum.take(limit)

--- a/lib/holobot/holofans/video.ex
+++ b/lib/holobot/holofans/video.ex
@@ -29,16 +29,7 @@ defmodule Holobot.Holofans.Video do
       live_start: video["live_start"],
       live_end: video["live_end"],
       live_viewers: video["live_viewers"],
-      channel:
-        video["channel"]
-        |> Map.take([
-          "yt_channel_id",
-          "name",
-          "twitter_link",
-          "view_count",
-          "subscriber_count",
-          "video_count"
-        ]),
+      channel: video["channel"]["yt_channel_id"],
       is_uploaded: video["is_uploaded"],
       duration_secs: video["duration_secs"],
       is_captioned: video["is_captioned"]

--- a/lib/holobot/telegram/commands/ask.ex
+++ b/lib/holobot/telegram/commands/ask.ex
@@ -62,13 +62,11 @@ defmodule Holobot.Telegram.Commands.Ask do
         send_message(@about_yagoo)
 
       "/ask why-digital-avatars" ->
-        send_message(
-         """
-         Various reasons. It's fun, it's unique, and it provides a degree of anonymity.
-         It's also to showcase how technology has advanced over recent years.
-         The idea of being a cartoon character in real-time was essentially unheard of even five years ago.
-         """
-        )
+        send_message("""
+        Various reasons. It's fun, it's unique, and it provides a degree of anonymity.
+        It's also to showcase how technology has advanced over recent years.
+        The idea of being a cartoon character in real-time was essentially unheard of even five years ago.
+        """)
     end
   end
 end

--- a/test/holofans/video_test.exs
+++ b/test/holofans/video_test.exs
@@ -6,14 +6,7 @@ defmodule Holobot.Holofans.VideoTest do
 
   test "build_record/1 returns a correctly built Video struct" do
     expected = %Video{
-      channel: %{
-        "name" => "Watson Amelia Ch. hololive-EN",
-        "subscriber_count" => 863_000,
-        "twitter_link" => "watsonameliaen",
-        "video_count" => 152,
-        "view_count" => 37_070_455,
-        "yt_channel_id" => "UCyl1z3jo3XHR1riLFKG5UAg"
-      },
+      channel: "UCyl1z3jo3XHR1riLFKG5UAg",
       duration_secs: nil,
       is_captioned: false,
       is_uploaded: false,

--- a/test/telegram/messages_test.exs
+++ b/test/telegram/messages_test.exs
@@ -5,20 +5,14 @@ defmodule MessagesTest do
   alias Holobot.Telegram.Messages
   alias Holobot.Holofans.Video
   alias Holobot.Holofans.Channel
+  alias Holobot.Holofans.Channels
   alias Nadia.Model.InlineQueryResult.Article
 
   import Mock
 
   @valid_vid %Video{
     __meta__: Memento.Table,
-    channel: %{
-      "name" => "Watson Amelia Ch. hololive-EN",
-      "subscriber_count" => 863_000,
-      "twitter_link" => "watsonameliaen",
-      "video_count" => 152,
-      "view_count" => 37_070_455,
-      "yt_channel_id" => "UCyl1z3jo3XHR1riLFKG5UAg"
-    },
+    channel: "UCyl1z3jo3XHR1riLFKG5UAg",
     duration_secs: nil,
     is_captioned: false,
     is_uploaded: false,
@@ -50,6 +44,18 @@ defmodule MessagesTest do
     [@valid_chan]
   end
 
+  setup_with_mocks([
+    {Channels, [],
+     [
+       get_channel: fn "UCyl1z3jo3XHR1riLFKG5UAg" ->
+         %Channel{name: "Watson Amelia Ch. hololive-EN"}
+       end
+     ]}
+  ]) do
+    foo = "bar"
+    {:ok, foo: foo}
+  end
+
   describe "stream messages" do
     test_with_mock(
       "build_msg_for_status/2 builds a msg of upcoming channels when stream hasn't started yet",
@@ -62,8 +68,14 @@ defmodule MessagesTest do
 
       msg = Messages.build_msg_for_status(vids, :upcoming)
 
-      expected_msg =
-        "⏰ *Upcoming streams*\n\n🔎Watson Amelia Ch. hololive-EN\nStarts in *30 minutes*\n[【BIRTHDAY STREAM】CAKE + a Special Announcement](https://youtu.be/_AbZB1uuVjA)\n\n"
+      expected_msg = """
+      ⏰ *Upcoming streams*
+
+      🔎Watson Amelia Ch. hololive-EN
+      Starts in *30 minutes*
+      [【BIRTHDAY STREAM】CAKE + a Special Announcement](https://youtu.be/_AbZB1uuVjA)
+
+      """
 
       assert expected_msg == msg
     end
@@ -76,7 +88,11 @@ defmodule MessagesTest do
     ) do
       # We mock the current UTC time to be 30 min after stream start
 
-      vids = video_fixture(%{live_start: "2021-01-07T01:00:00.000Z"})
+      vids =
+        video_fixture(%{
+          live_start: "2021-01-07T01:00:00.000Z",
+          name: "Watson Amelia Ch. hololive-EN"
+        })
 
       msg = Messages.build_msg_for_status(vids, :live)
 


### PR DESCRIPTION
This implements efficient mapping between the Video and Channel domains. Before each Video record would contain a map of a channel, now it is replaced with just the yt video key, which allows for fast and efficient lookup of a cached channel by primary key, saving on memory.